### PR TITLE
combine binance websocket subscriptions into a single message

### DIFF
--- a/oracle/provider/binance.go
+++ b/oracle/provider/binance.go
@@ -144,15 +144,16 @@ func NewBinanceProvider(
 }
 
 func (p *BinanceProvider) getSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {
-	subscriptionMsgs := make([]interface{}, 0, len(p.subscribedPairs)*2)
-	for _, cp := range cps {
-		binanceTickerPair := currencyPairToBinanceTickerPair(cp)
-		subscriptionMsgs = append(subscriptionMsgs, newBinanceSubscriptionMsg(binanceTickerPair))
-
-		binanceCandlePair := currencyPairToBinanceCandlePair(cp)
-		subscriptionMsgs = append(subscriptionMsgs, newBinanceSubscriptionMsg(binanceCandlePair))
+	msg := BinanceSubscriptionMsg{
+		Method: "SUBSCRIBE",
+		Params: make([]string, len(cps) * 2),
+		ID:     1,
 	}
-	return subscriptionMsgs
+	for i, cp := range cps {
+		msg.Params[i * 2] = strings.ToLower(cp.String()) + "@ticker"
+		msg.Params[i * 2 + 1] = strings.ToLower(cp.String()) + "@kline_1m"
+	}
+	return []interface{}{msg}
 }
 
 // SubscribeCurrencyPairs sends the new subscription messages to the websocket
@@ -334,25 +335,4 @@ func (p *BinanceProvider) GetAvailablePairs() (map[string]struct{}, error) {
 	}
 
 	return availablePairs, nil
-}
-
-// currencyPairToBinanceTickerPair receives a currency pair and return binance
-// ticker symbol atomusdt@ticker.
-func currencyPairToBinanceTickerPair(cp types.CurrencyPair) string {
-	return strings.ToLower(cp.String() + "@ticker")
-}
-
-// currencyPairToBinanceCandlePair receives a currency pair and return binance
-// candle symbol atomusdt@kline_1m.
-func currencyPairToBinanceCandlePair(cp types.CurrencyPair) string {
-	return strings.ToLower(cp.String() + "@kline_1m")
-}
-
-// newBinanceSubscriptionMsg returns a new subscription Msg.
-func newBinanceSubscriptionMsg(params ...string) BinanceSubscriptionMsg {
-	return BinanceSubscriptionMsg{
-		Method: "SUBSCRIBE",
-		Params: params,
-		ID:     1,
-	}
 }

--- a/oracle/provider/binance_test.go
+++ b/oracle/provider/binance_test.go
@@ -79,12 +79,6 @@ func TestBinanceProvider_GetTickerPrices(t *testing.T) {
 	})
 }
 
-func TestBinanceCurrencyPairToBinancePair(t *testing.T) {
-	cp := types.CurrencyPair{Base: "ATOM", Quote: "USDT"}
-	binanceSymbol := currencyPairToBinanceTickerPair(cp)
-	require.Equal(t, binanceSymbol, "atomusdt@ticker")
-}
-
 func TestBinanceProvider_getSubscriptionMsgs(t *testing.T) {
 	provider := &BinanceProvider{
 		subscribedPairs: map[string]types.CurrencyPair{},
@@ -96,8 +90,5 @@ func TestBinanceProvider_getSubscriptionMsgs(t *testing.T) {
 	subMsgs := provider.getSubscriptionMsgs(cps...)
 
 	msg, _ := json.Marshal(subMsgs[0])
-	require.Equal(t, "{\"method\":\"SUBSCRIBE\",\"params\":[\"atomusdt@ticker\"],\"id\":1}", string(msg))
-
-	msg, _ = json.Marshal(subMsgs[1])
-	require.Equal(t, "{\"method\":\"SUBSCRIBE\",\"params\":[\"atomusdt@kline_1m\"],\"id\":1}", string(msg))
+	require.Equal(t, "{\"method\":\"SUBSCRIBE\",\"params\":[\"atomusdt@ticker\",\"atomusdt@kline_1m\"],\"id\":1}", string(msg))
 }


### PR DESCRIPTION
Binance websocket handles a max of 5 messages at a time so sending separate subscribe messages meant only 2 pairs would be supported.